### PR TITLE
Direct insert to sql

### DIFF
--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -11,10 +11,10 @@ cron:
 #  url: /calc_daily
 #  schedule: every day 04:00
 #  timezone: Asia/Tokyo
-- description: "insert stockprice daily into cloud sql from spreadsheet"
-  url: /daily_to_sql
-  schedule: every day 02:30
-  timezone: Asia/Tokyo
+#- description: "insert stockprice daily into cloud sql from spreadsheet"
+#  url: /daily_to_sql
+#  schedule: every day 02:30
+#  timezone: Asia/Tokyo
 - description: "delete daily sheet data, after confirming db"
   url: /delete_sheet
   schedule: every day 02:45

--- a/src/main.go
+++ b/src/main.go
@@ -111,7 +111,7 @@ func dailyToSqlHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// dailypriceをcloudsqlに挿入
-		ins, err := insertDailyPrice(r, db, "daily", dailyColumns, resp[begin:end])
+		ins, err := insertData(r, db, "daily", dailyColumns, resp[begin:end])
 		if err != nil {
 			log.Errorf(ctx, "failed to insert. %v", err)
 		}
@@ -357,7 +357,7 @@ func mustGetenv(r *http.Request, k string) string {
 //		// 指定された複数の銘柄単位でcodeをScrape
 //		prices := getEachCodesPrices(r, codes[begin:end])
 //		// dailypriceをcloudsqlに挿入
-//		insertDailyPrice(r, db, "daily", prices)
+//		insertData(r, db, "daily", prices)
 //
 //		//tar, ins := scrapeAndWriteSql(r, db, codes[begin:end])
 //		target += tar

--- a/src/main.go
+++ b/src/main.go
@@ -515,10 +515,6 @@ func movingAvgHandler(w http.ResponseWriter, r *http.Request) {
 
 }
 
-// X日移動平均線を計算する
-//func movingAverage(r *http.Request, dcs []dateClose, avgDays int) map[string]float64 {
-//	// GAE log
-//	ctx := appengine.NewContext(r)
 func movingAverage(dcs []dateClose, avgDays int) map[string]float64 {
 
 	dateMovingMap := make(map[string]float64) // 日付と移動平均のMap
@@ -548,68 +544,6 @@ func movingAverage(dcs []dateClose, avgDays int) map[string]float64 {
 	//log.Infof(ctx, "%d %v", avgDays, dateMovingMap)
 	return dateMovingMap
 }
-
-//func indexHandlerCalcDailyOld(w http.ResponseWriter, r *http.Request) {
-//	// GAE log
-//	ctx := appengine.NewContext(r)
-//
-//	// read environment values
-//	getEnv(r)
-//
-//	// spreadsheetのclientを取得
-//	sheetService, err := getSheetClient(r)
-//	if err != nil {
-//		log.Errorf(ctx, "err: %v", err)
-//		os.Exit(0)
-//	}
-//
-//	if !isBussinessday(sheetService, r) {
-//		log.Infof(ctx, "Is not a business day today.")
-//		return
-//	}
-//
-//	// spreadsheetから銘柄コードを取得
-//	//codes := readCode(sheetService, r, "ichibu")
-//	codes := getSheetData(r, sheetService, CODE_SHEETID, "ichibu")
-//	if codes == nil || len(codes) == 0 {
-//		log.Infof(ctx, "No target data.")
-//		return
-//	}
-//
-//	// spreadsheetから株価を取得する
-//	resp := getSheetData(r, sheetService, DAILYPRICE_SHEETID, "daily")
-//	if resp == nil {
-//		log.Infof(ctx, "No data")
-//		return
-//	}
-//
-//	cdmp := codeDateModprice(r, resp)
-//	//log.Infof(ctx, "%v\n", cdmp)
-//
-//	// 全codeの株価比率
-//	var whole_codeRate []codeRate
-//	for _, row := range codes {
-//		code := row[0].(string)
-//		//直近7日間の増減率を取得する
-//		rate, err := calcIncreaseRate(cdmp, code, 7, r)
-//		if err != nil {
-//			log.Warningf(ctx, "%v\n", err)
-//			continue
-//		}
-//		whole_codeRate = append(whole_codeRate, codeRate{code, rate})
-//	}
-//	log.Infof(ctx, "count whole code %v\n", len(whole_codeRate))
-//
-//	// 一つ前との比率が一番大きいもの順にソート
-//	sort.SliceStable(whole_codeRate, func(i, j int) bool { return whole_codeRate[i].Rate[0] > whole_codeRate[j].Rate[0] })
-//	//fmt.Fprintln(w, whole_codeRate)
-//
-//	// 事前にrateのシートをclear
-//	clearSheet(sheetService, r, DAILYRATE_SHEETID, "daily_rate")
-//
-//	// 株価の比率順にソートしたものを書き込み
-//	writeRate(sheetService, r, whole_codeRate, DAILYRATE_SHEETID, "daily_rate")
-//}
 
 func codeDateModprice(r *http.Request, resp [][]interface{}) [][]interface{} {
 	//ctx := appengine.NewContext(r)

--- a/src/prod.yaml
+++ b/src/prod.yaml
@@ -27,6 +27,6 @@ env_variables:
   # cloud sql
   CLOUDSQL_CONNECTION_NAME: "myfinance-01:asia-northeast1:myfinance"
   CLOUDSQL_USER: root
-  MAX_SQL_INSERT: 1000
+  MAX_SQL_INSERT: 100
 includes:
 - cloudsql_secret.yaml

--- a/src/sqltools.go
+++ b/src/sqltools.go
@@ -37,27 +37,27 @@ func dialSql(r *http.Request) (*sql.DB, error) {
 	return sql.Open("mysql", fmt.Sprintf("%s:%s@cloudsql(%s)/stockprice", user, password, connectionName))
 }
 
-func insertDailyPrice(r *http.Request, db *sql.DB, table string, columns []string, resp [][]interface{}) (int, error) {
+func insertData(r *http.Request, db *sql.DB, table string, columns []string, records [][]interface{}) (int, error) {
 	ctx := appengine.NewContext(r)
 
 	// insert対象を組み立てる
 	// TODO: +=の文字列結合は遅いので改良する
 	ins := ""
-	for _, line := range resp {
+	for _, record := range records {
 		// 一行ごとに('項目1',..., '最後の項目'), の形でINSERT対象を組み立て
 		ins += "("
-		for i := 0; i < len(line)-1; i++ {
-			ins += fmt.Sprintf("'%s',", line[i])
+		for i := 0; i < len(record)-1; i++ {
+			ins += fmt.Sprintf("'%s',", record[i])
 		}
 		// 最後の項目だけ後ろに","が不要なので分けて記載
-		ins += fmt.Sprintf("'%s'),", line[len(line)-1])
+		ins += fmt.Sprintf("'%s'),", record[len(record)-1])
 	}
 	// 末尾の,を除去
 	ins = strings.TrimRight(ins, ",")
 	//log.Debugf(ctx, "ins: %v", ins)
 
 	// 挿入対象の件数
-	targetNum := len(resp)
+	targetNum := len(records)
 
 	log.Infof(ctx, "trying to insert %d values to '%s' table.", targetNum, table)
 	// INSERT IGNORE INTO 'table名' (項目名1, 項目名2...) VALUES (...), (...)の形
@@ -85,7 +85,7 @@ func insertMovingAvg(r *http.Request, db *sql.DB, table string, code string, dat
 
 	// insert対象を組み立てる
 	// TODO: +=の文字列結合は遅いので改良する
-	// TODO: 上のinsertDailyPriceと共通化したい
+	// TODO: 上のinsertDataと共通化したい
 	ins := ""
 	for _, date := range dateList {
 		//		log.Infof(ctx, "code %s, date %s, 5: %v, 20: %v, 60: %v, 100 %v", date, mvavg[5][date], mvavg[20][date], mvavg[60][date], mvavg[100][date])

--- a/src/sqltools.go
+++ b/src/sqltools.go
@@ -37,6 +37,52 @@ func dialSql(r *http.Request) (*sql.DB, error) {
 	return sql.Open("mysql", fmt.Sprintf("%s:%s@cloudsql(%s)/stockprice", user, password, connectionName))
 }
 
+// TODO: insertDataの引数が[][]stringのもの。どちらかに統一する
+// insert対象のtable名、項目名、レコードを引数に取ってDBに書き込む
+func insertDataStrings(r *http.Request, db *sql.DB, table string, columns []string, records [][]string) (int, error) {
+	ctx := appengine.NewContext(r)
+
+	// insert対象を組み立てる
+	// TODO: +=の文字列結合は遅いので改良する
+	ins := ""
+	for _, record := range records {
+		// 一行ごとに('項目1',..., '最後の項目'), の形でINSERT対象を組み立て
+		ins += "("
+		for i := 0; i < len(record)-1; i++ {
+			ins += fmt.Sprintf("'%s',", record[i])
+		}
+		// 最後の項目だけ後ろに","が不要なので分けて記載
+		ins += fmt.Sprintf("'%s'),", record[len(record)-1])
+	}
+	// 末尾の,を除去
+	ins = strings.TrimRight(ins, ",")
+	//log.Debugf(ctx, "ins: %v", ins)
+
+	// 挿入対象の件数
+	targetNum := len(records)
+
+	log.Infof(ctx, "trying to insert %d values to '%s' table.", targetNum, table)
+	// INSERT IGNORE INTO 'table名' (項目名1, 項目名2...) VALUES (...), (...)の形
+	// queryを組み立て
+	query := fmt.Sprintf("INSERT IGNORE INTO %s (", table)
+	for _, c := range columns {
+		query += fmt.Sprintf("%s,", c)
+	}
+	// 末尾の,を除去
+	query = strings.TrimRight(query, ", ")
+	query += fmt.Sprintf(") VALUES %s;", ins)
+
+	//log.Debugf(ctx, "query: %v", query)
+	rows, err := db.Query(query)
+	if err != nil {
+		log.Errorf(ctx, "failed to insert table: %s, err: %v, query: %v", table, err, query)
+		return 0, err
+	}
+	defer rows.Close()
+	return targetNum, nil
+}
+
+// insert対象のtable名、項目名、レコードを引数に取ってDBに書き込む
 func insertData(r *http.Request, db *sql.DB, table string, columns []string, records [][]interface{}) (int, error) {
 	ctx := appengine.NewContext(r)
 

--- a/src/sqltools.go
+++ b/src/sqltools.go
@@ -150,7 +150,7 @@ func insertMovingAvg(r *http.Request, db *sql.DB, table string, code string, dat
 		log.Errorf(ctx, "failed to insert table: %s, err: %v, query: %v", table, err, query)
 		return
 	}
-	log.Infof(ctx, "succeded to insert %s", table)
+	log.Infof(ctx, "succeeded to insert %s", table)
 	defer rows.Close()
 }
 

--- a/src/sqltools.go
+++ b/src/sqltools.go
@@ -82,49 +82,49 @@ func insertDataStrings(r *http.Request, db *sql.DB, table string, columns []stri
 	return targetNum, nil
 }
 
-// insert対象のtable名、項目名、レコードを引数に取ってDBに書き込む
-func insertData(r *http.Request, db *sql.DB, table string, columns []string, records [][]interface{}) (int, error) {
-	ctx := appengine.NewContext(r)
-
-	// insert対象を組み立てる
-	// TODO: +=の文字列結合は遅いので改良する
-	ins := ""
-	for _, record := range records {
-		// 一行ごとに('項目1',..., '最後の項目'), の形でINSERT対象を組み立て
-		ins += "("
-		for i := 0; i < len(record)-1; i++ {
-			ins += fmt.Sprintf("'%s',", record[i])
-		}
-		// 最後の項目だけ後ろに","が不要なので分けて記載
-		ins += fmt.Sprintf("'%s'),", record[len(record)-1])
-	}
-	// 末尾の,を除去
-	ins = strings.TrimRight(ins, ",")
-	//log.Debugf(ctx, "ins: %v", ins)
-
-	// 挿入対象の件数
-	targetNum := len(records)
-
-	log.Infof(ctx, "trying to insert %d values to '%s' table.", targetNum, table)
-	// INSERT IGNORE INTO 'table名' (項目名1, 項目名2...) VALUES (...), (...)の形
-	// queryを組み立て
-	query := fmt.Sprintf("INSERT IGNORE INTO %s (", table)
-	for _, c := range columns {
-		query += fmt.Sprintf("%s,", c)
-	}
-	// 末尾の,を除去
-	query = strings.TrimRight(query, ", ")
-	query += fmt.Sprintf(") VALUES %s;", ins)
-
-	//log.Debugf(ctx, "query: %v", query)
-	rows, err := db.Query(query)
-	if err != nil {
-		log.Errorf(ctx, "failed to insert table: %s, err: %v, query: %v", table, err, query)
-		return 0, err
-	}
-	defer rows.Close()
-	return targetNum, nil
-}
+//// insert対象のtable名、項目名、レコードを引数に取ってDBに書き込む
+//func insertData(r *http.Request, db *sql.DB, table string, columns []string, records [][]interface{}) (int, error) {
+//	ctx := appengine.NewContext(r)
+//
+//	// insert対象を組み立てる
+//	// TODO: +=の文字列結合は遅いので改良する
+//	ins := ""
+//	for _, record := range records {
+//		// 一行ごとに('項目1',..., '最後の項目'), の形でINSERT対象を組み立て
+//		ins += "("
+//		for i := 0; i < len(record)-1; i++ {
+//			ins += fmt.Sprintf("'%s',", record[i])
+//		}
+//		// 最後の項目だけ後ろに","が不要なので分けて記載
+//		ins += fmt.Sprintf("'%s'),", record[len(record)-1])
+//	}
+//	// 末尾の,を除去
+//	ins = strings.TrimRight(ins, ",")
+//	//log.Debugf(ctx, "ins: %v", ins)
+//
+//	// 挿入対象の件数
+//	targetNum := len(records)
+//
+//	log.Infof(ctx, "trying to insert %d values to '%s' table.", targetNum, table)
+//	// INSERT IGNORE INTO 'table名' (項目名1, 項目名2...) VALUES (...), (...)の形
+//	// queryを組み立て
+//	query := fmt.Sprintf("INSERT IGNORE INTO %s (", table)
+//	for _, c := range columns {
+//		query += fmt.Sprintf("%s,", c)
+//	}
+//	// 末尾の,を除去
+//	query = strings.TrimRight(query, ", ")
+//	query += fmt.Sprintf(") VALUES %s;", ins)
+//
+//	//log.Debugf(ctx, "query: %v", query)
+//	rows, err := db.Query(query)
+//	if err != nil {
+//		log.Errorf(ctx, "failed to insert table: %s, err: %v, query: %v", table, err, query)
+//		return 0, err
+//	}
+//	defer rows.Close()
+//	return targetNum, nil
+//}
 
 func insertMovingAvg(r *http.Request, db *sql.DB, table string, code string, dateList []string, mvavg map[int]map[string]float64) {
 	ctx := appengine.NewContext(r)


### PR DESCRIPTION
SpreadSheetに入れたりSheetから読み取ったりするのをやめて直接CloudSQLに書き込む

## 変更点
- dailyToSqlHandler: Sheetの中身をSQLに書き込む処理が不要になった
- indexHandlerDaily: Sheetに書き込んでいた処理を削除する
- scrapeAndWrite: この関数が存在する意味がなくなった
- getUniqPrice: ユニークなデータを確認する必要がなくなったので削除